### PR TITLE
Add gitlab linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To use this feature set up a link with
 
     $ herodot link
 
-You are then guided through the process of linking. When using JIRA or Github with tickety-tick, this should be rather self-explaining, but you can also set up a custom tracker if you are using something different. Just choose `other` and add a URL, to which issue numbers can be appended and a Ruby style regular expression, to cut out the issue number out of your branches.
+You are then guided through the process of linking. When using JIRA, Github, or GitLab with tickety-tick, this should be rather self-explaining, but you can also set up a custom tracker if you are using something different. Just choose `other` and add a URL, to which issue numbers can be appended and a Ruby style regular expression, to cut out the issue number out of your branches.
 
 The result will be written into a  `.herodot.yml` file in the current or specified directory.
 

--- a/lib/herodot/commands.rb
+++ b/lib/herodot/commands.rb
@@ -37,6 +37,7 @@ class Herodot::Commands
       menu.prompt = 'What tracker do you want to link to?'
       menu.choice(:jira) { link_jira(path) }
       menu.choice(:github) { link_github(path) }
+      menu.choice(:gitlab) { link_gitlab(path) }
       menu.choices(:other) { link_other(path) }
       menu.default = :other
     end
@@ -51,6 +52,11 @@ class Herodot::Commands
   def self.link_github(path)
     handle = ask('Github handle (something/something for https://github.com/something/something)?')
     Herodot::ProjectLink.link(path, "https://github.com/#{handle}/issues/", '\\d+')
+  end
+
+  def self.link_gitlab(path)
+    handle = ask('GitLab handle (something/something for https://gitlab.com/something/something)?')
+    Herodot::ProjectLink.link(path, "https://gitlab.com/#{handle}/issues/", '\\d+')
   end
 
   def self.link_other(path)

--- a/lib/herodot/version.rb
+++ b/lib/herodot/version.rb
@@ -1,3 +1,3 @@
 module Herodot
-  VERSION = '0.1.9'.freeze
+  VERSION = '0.1.10'.freeze
 end


### PR DESCRIPTION
does what it says on the bin - it allows linking branches to https://gitlab.com/

![](https://rrott.com/images/blog/safari-svg-animation/bad-logo-safari.gif)

