### PR TITLE
Update tracking mechanism for easier updates

### DIFF
--- a/lib/herodot.rb
+++ b/lib/herodot.rb
@@ -19,6 +19,7 @@ class Herodot::Application
 
     config = Herodot::Configuration.new
     init_command(config)
+    track_command(config)
     show_command(config)
     link_command(config)
     default_command :show
@@ -35,6 +36,20 @@ class Herodot::Application
       c.example 'Start tracking current repository', 'herodot init'
       c.action do |args, _|
         Herodot::Commands.init(args[0], config)
+      end
+    end
+  end
+
+  TRACK_DESCRIPTION = 'This command tracks the current branch/commit in a repo '\
+                      'and is called from the git hooks installed via `herodot init`.'.freeze
+  def track_command(config)
+    command :track do |c|
+      c.syntax = 'herodot track <repository path>'
+      c.summary = 'Record git activity in a repository (used internally)'
+      c.description = TRACK_DESCRIPTION
+      c.example 'Record the latest branch name etc. to the worklog', 'herodot track .'
+      c.action do |args, _|
+        Herodot::Commands.track(args[0], config)
       end
     end
   end

--- a/lib/herodot.rb
+++ b/lib/herodot.rb
@@ -18,23 +18,23 @@ class Herodot::Application
     program :description, 'Tracks your work based on git branch checkouts'
 
     config = Herodot::Configuration.new
-    track_command(config)
+    init_command(config)
     show_command(config)
     link_command(config)
     default_command :show
     run!
   end
 
-  TRACK_DESCRIPTION = 'This command sets up post commit and post checkout hooks'\
+  INIT_DESCRIPTION = 'This command sets up post commit and post checkout hooks'\
                       ', that will log the current branch into the worklog file.'.freeze
-  def track_command(config)
-    command :track do |c|
-      c.syntax = 'herodot track [<repository path>]'
+  def init_command(config)
+    command :init do |c|
+      c.syntax = 'herodot init [<repository path>]'
       c.summary = 'Start tracking a repository'
-      c.description = TRACK_DESCRIPTION
-      c.example 'Start tracking current repository', 'herodot track'
+      c.description = INIT_DESCRIPTION
+      c.example 'Start tracking current repository', 'herodot init'
       c.action do |args, _|
-        Herodot::Commands.track(args[0], config)
+        Herodot::Commands.init(args[0], config)
       end
     end
   end

--- a/lib/herodot/commands.rb
+++ b/lib/herodot/commands.rb
@@ -19,7 +19,7 @@ class Herodot::Commands
     puts output
   end
 
-  def self.track(path, config)
+  def self.init(path, config)
     path = '.' if path.nil?
     puts "Start tracking of `#{File.expand_path(path)}` into `#{config.worklog_file}`."
     hooks = "#{path}/.git/hooks"

--- a/lib/herodot/commands.rb
+++ b/lib/herodot/commands.rb
@@ -1,12 +1,10 @@
+require 'date'
 require 'chronic'
 require 'fileutils'
 
 class Herodot::Commands
-  SCRIPT = "#!/bin/bash\n"\
-           "echo 'Logging into worklog'\n"\
-           "project=$(pwd)\n"\
-           "branch=$(git rev-parse --abbrev-ref HEAD)\n"\
-           'echo "$(date);$project;$branch" >> ~/.worklog'.freeze
+  SCRIPT = "#!/bin/sh\nherodot track $(pwd)".freeze
+
   DEFAULT_RANGE = 'this week'.freeze
 
   def self.show(args, config, opts = {})
@@ -28,6 +26,16 @@ class Herodot::Commands
       File.open("#{hooks}/#{name}", 'w') { |file| file.write(SCRIPT) }
       File.chmod(0o755, "#{hooks}/#{name}")
       FileUtils.touch(config.worklog_file)
+    end
+  end
+
+  def self.track(path, config)
+    puts 'Logging into worklog'
+    File.open(config.worklog_file, 'a') do |worklog|
+      datestr = DateTime.now.strftime("%a %b %e %H:%M:%S %z %Y")
+      branch = `(cd #{path} && git rev-parse --abbrev-ref HEAD)`.strip
+      line = [datestr, path, branch].join(";")
+      worklog.puts(line)
     end
   end
 

--- a/lib/herodot/parser.rb
+++ b/lib/herodot/parser.rb
@@ -2,7 +2,7 @@ require 'csv'
 
 class Herodot::Parser
   NO_SUCH_FILE = Rainbow('Worklog missing.').red +
-                 ' Use `herodot track` to track a git repository'\
+                 ' Use `herodot init` to start tracking a git repository'\
                  ' or `herodot help` to open the man page.'.freeze
   class << self
     def parse(range, config)

--- a/post-checkout
+++ b/post-checkout
@@ -1,6 +1,0 @@
-#!/bin/bash
-echo 'Logging into worklog'
-project=$(pwd)
-branch=$(git rev-parse --abbrev-ref HEAD)
-
-echo "$(date);$project;$branch" >> ~/worklog


### PR DESCRIPTION
Instead of having all logic regarding

- the worklog file path (was previously hardcoded and not taken from config),
- the worklog file format,
- which and how to retrieve the logged values

in duplicated git hook scripts, let hooks delegate the recording of this data back to the `herodot` tool itself.

This should make updating herodot easier as we do not have to worry as much about updating the scattered git hook scripts that are copied everywhere.

Existing hooks should continue to work as the worklog format stays the same. Only newly herodot-initialized repos will have the simpler hooks (it may be worth upgrading old ones).

The `herodot track` command has been renamed to `herodot init` (to mirror `git init` and because it is a one-time action).

Instead, `herodot track <path>` will be called to append an entry to the worklog.