### PR TITLE
Make the worklog file hidden

### DIFF
--- a/lib/herodot/commands.rb
+++ b/lib/herodot/commands.rb
@@ -6,7 +6,7 @@ class Herodot::Commands
            "echo 'Logging into worklog'\n"\
            "project=$(pwd)\n"\
            "branch=$(git rev-parse --abbrev-ref HEAD)\n"\
-           'echo "$(date);$project;$branch" >> ~/worklog'.freeze
+           'echo "$(date);$project;$branch" >> ~/.worklog'.freeze
   DEFAULT_RANGE = 'this week'.freeze
 
   def self.show(args, config, opts = {})

--- a/lib/herodot/configuration.rb
+++ b/lib/herodot/configuration.rb
@@ -12,7 +12,7 @@ class Herodot::Configuration
     }
   }.freeze
 
-  def initialize(worklog_file = '~/worklog')
+  def initialize(worklog_file = '~/.worklog')
     @worklog_file = worklog_file
     if File.exist?(CONFIG_FILE)
       @config = load_configuration


### PR DESCRIPTION
*Warning ⚠️* This is a breaking change, as we would have to update all the git hook scripts, as the worklog path is hardcoded in them. Also people should `mv ~/worklog ~/.worklog`.

Personally, I don't want the worklog file to clutter my home directory. How about we make it hidden?