### PR TITLE
[#9] Run rubocop in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,22 @@
 sudo: false
 language: ruby
+
 rvm:
-  - 2.0.0
-  - 2.3.3
-before_install: gem install bundler -v 1.14.4
+  - 2.1.0
+  - 2.3.5
+  - 2.4.2
+
+before_install:
+  - gem install bundler -v 1.14.6
+
+install:
+  - gem update --system
+  - bundle install --jobs=3 --retry=3
+
+cache:
+  bundler: true
+  directories:
+    - vendor/bundle
+
+script:
+  - bin/ci

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,64 @@
+PATH
+  remote: .
+  specs:
+    herodot (0.2.0)
+      chronic
+      commander
+      rainbow
+      terminal-table
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.3.0)
+    chronic (0.10.2)
+    commander (4.4.3)
+      highline (~> 1.7.2)
+    diff-lcs (1.3)
+    highline (1.7.8)
+    parser (2.4.0.0)
+      ast (~> 2.2)
+    powerpack (0.1.1)
+    rainbow (2.2.1)
+    rake (10.5.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    rubocop (0.47.1)
+      parser (>= 2.3.3.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    rubocop-bitcrowd (1.0.0)
+    rubocop-rspec (1.13.0)
+      rubocop (>= 0.42.0)
+    ruby-progressbar (1.8.1)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
+    unicode-display_width (1.1.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.14)
+  herodot!
+  rake (~> 10.0)
+  rspec (~> 3.0)
+  rubocop
+  rubocop-bitcrowd
+  rubocop-rspec
+
+BUNDLED WITH
+   1.14.6

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Install with:
 
     $ gem install herodot
 
+Make sure you have installed at least ruby 2.1 or any newer ruby version.
+
 ## Usage
 
 Track a git repository:
@@ -50,6 +52,7 @@ Show Help:
     $ herodot help show
 
 ## Linking to issue trackers
+
 If you use https://github.com/bitcrowd/tickety-tick or otherwise have branch names, that contain
 the issue number, you can link a tracked herodot repository with your issue tracker, so it
 will print urls of issues it recognizes under the branch name.

--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+require 'English'
+
+module TravisRunner
+  def self.execute(title, command)
+    puts "== Running #{title} =="
+    system command
+    yield if block_given?
+    raise "#{title} failed" unless $CHILD_STATUS.success?
+  end
+end
+
+system 'mkdir -p tmp'
+
+TravisRunner.execute 'Rubocop', 'bundle exec rubocop'
+TravisRunner.execute 'Rspec', 'bundle exec rspec --exclude-pattern "spec/features/**/*"'

--- a/lib/herodot/commands.rb
+++ b/lib/herodot/commands.rb
@@ -32,9 +32,9 @@ class Herodot::Commands
   def self.track(path, config)
     puts 'Logging into worklog'
     File.open(config.worklog_file, 'a') do |worklog|
-      datestr = DateTime.now.strftime("%a %b %e %H:%M:%S %z %Y")
+      datestr = DateTime.now.strftime('%a %b %e %H:%M:%S %z %Y')
       branch = `(cd #{path} && git rev-parse --abbrev-ref HEAD)`.strip
-      line = [datestr, path, branch].join(";")
+      line = [datestr, path, branch].join(';')
       worklog.puts(line)
     end
   end


### PR DESCRIPTION
**TL;DR**

* attempt to fix #9 
* apply CI hints Andy gave in his last lunch talk
* test the latest ruby version
* require a minimal ruby version of `2.1` (from `2.0`)
* track `Gemfile.lock` in git

**Longer version**

Different rubocop-versions have different cops (and, thus, require different code formattings). This is why we need to have the same rubocop version for all ruby-version builds. To achieve that, I removed `Gemfile.lock` from `.gitignore`. With a `Gemfile.lock` in version control, we check against the same rubocop configuration for all builds.

Next task is to find a set of gems working on all supported ruby versions. Because of the ruby-2.0.0 error

```
rubocop-rspec-1.13.0 requires ruby version >= 2.1.0, which is incompatible with
```

I decided to require a minimal ruby version of `2.1` (instead of downgrading rubocop-rspec). Hope that's OK with everyone here.


