### PR TITLE
[#11] `add_entry': undefined method `gsub' for nil:NilClass

### DIFF
--- a/lib/herodot/configuration.rb
+++ b/lib/herodot/configuration.rb
@@ -27,11 +27,12 @@ class Herodot::Configuration
   end
 
   def projects_directory
-    File.expand_path(@config['projects_directory'])
+    File.expand_path(@config['projects_directory'] || DEFAULT_CONFIGURATION['projects_directory'])
   end
 
   def work_times
-    @config['work_times'].map { |k, v| [k.to_sym, v.split(':').map(&:to_i)] }
+    (@config['work_times'] || DEFAULT_CONFIGURATION['work_times'])
+      .map { |k, v| [k.to_sym, v.split(':').map(&:to_i)] }
   end
 
   def save_configuration


### PR DESCRIPTION
Seems as if #11 was due to an empty .herodot.yml.
With this change herodot should assume defaults if the file is empty.